### PR TITLE
fix: include 'repoOrg/repoName' in the updatebot PR title

### DIFF
--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -2,16 +2,17 @@ package pr
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/jenkins-x/jx-gitops/pkg/cmd/git/setup"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/gitclient"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/helmer"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/scmhelpers"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/stringhelpers"
 	"github.com/shurcooL/githubv4"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/jenkins-x-plugins/jx-updatebot/pkg/apis/updatebot/v1alpha1"
 	"github.com/jenkins-x-plugins/jx-updatebot/pkg/rootcmd"
@@ -168,7 +169,9 @@ func (o *Options) Run() error {
 
 				}
 				if o.PullRequestTitle == "" {
-					o.PullRequestTitle = fmt.Sprintf("fix: upgrade to version %s", o.Version)
+					gitURLpart := strings.Split(gitURL, "/")
+					repository := gitURLpart[len(gitURLpart)-2] + "/" + gitURLpart[len(gitURLpart)-1]
+					o.PullRequestTitle = fmt.Sprintf("chore: upgrade %s to version %s", repository, o.Version)
 				}
 				if o.CommitTitle == "" {
 					o.CommitTitle = o.PullRequestTitle


### PR DESCRIPTION
Avoid having a lot of PRs with similar titles:  
<img width="150" alt="image" src="https://user-images.githubusercontent.com/52448671/106958030-16e78300-6739-11eb-8ccc-3ab523ca1acc.png">

Changed 'fix' to 'chore', as a dependance version bump isn't necessarily a fix