### PR TITLE
refactor: use T.TempDir to create temporary test directory

### DIFF
--- a/pkg/cmd/argo/promote/applications_test.go
+++ b/pkg/cmd/argo/promote/applications_test.go
@@ -14,11 +14,10 @@ import (
 )
 
 func TestModifyApplicationFiles(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	t.Logf("using dir %s\n", tmpDir)
-	err = files.CopyDirOverwrite("test_data", tmpDir)
+	err := files.CopyDirOverwrite("test_data", tmpDir)
 	require.NoError(t, err, "failed to copy test data to %s", tmpDir)
 
 	dirNames, err := ioutil.ReadDir(tmpDir)

--- a/pkg/cmd/argo/sync/sync_test.go
+++ b/pkg/cmd/argo/sync/sync_test.go
@@ -22,10 +22,9 @@ var (
 )
 
 func TestArgoSync(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "failed to create temp dir")
+	tmpDir := t.TempDir()
 
-	err = files.CopyDirOverwrite("test_data", tmpDir)
+	err := files.CopyDirOverwrite("test_data", tmpDir)
 	require.NoError(t, err, "failed to copy test_data to %s", tmpDir)
 
 	fileSlice, err := ioutil.ReadDir(tmpDir)

--- a/pkg/cmd/flux/promote/charts_test.go
+++ b/pkg/cmd/flux/promote/charts_test.go
@@ -19,11 +19,10 @@ var (
 )
 
 func TestModifyHelmReleaseFiles(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "could not create temp dir")
+	tmpDir := t.TempDir()
 
 	t.Logf("using dir %s\n", tmpDir)
-	err = files.CopyDirOverwrite("test_data", tmpDir)
+	err := files.CopyDirOverwrite("test_data", tmpDir)
 	require.NoError(t, err, "failed to copy test data to %s", tmpDir)
 
 	dirNames, err := ioutil.ReadDir(tmpDir)

--- a/pkg/cmd/flux/sync/sync_test.go
+++ b/pkg/cmd/flux/sync/sync_test.go
@@ -22,10 +22,9 @@ var (
 )
 
 func TestFluxSync(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "failed to create temp dir")
+	tmpDir := t.TempDir()
 
-	err = files.CopyDirOverwrite("test_data", tmpDir)
+	err := files.CopyDirOverwrite("test_data", tmpDir)
 	require.NoError(t, err, "failed to copy test_data to %s", tmpDir)
 
 	fileSlice, err := ioutil.ReadDir(tmpDir)

--- a/pkg/cmd/sync/sync_test.go
+++ b/pkg/cmd/sync/sync_test.go
@@ -18,8 +18,7 @@ var (
 )
 
 func TestSync(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err, "failed to create temp dir")
+	tmpDir := t.TempDir()
 
 	testDir := "test_data"
 	fileSlice, err := ioutil.ReadDir(testDir)


### PR DESCRIPTION
Follow up PR for https://github.com/jenkins-x-plugins/jx-gitops/pull/839#issuecomment-1079479757. This PR replaces `ioutil.TempDir` with `t.TempDir` in tests.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir