### PR TITLE
fix(pr): add --base-branch-name option for pull requests command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/helmfile/helmfile v0.146.0
 	github.com/jenkins-x-plugins/jx-gitops v0.10.5
 	github.com/jenkins-x-plugins/jx-pipeline v0.5.9
-	github.com/jenkins-x-plugins/jx-promote v0.4.4
+	github.com/jenkins-x-plugins/jx-promote v0.4.5
 	github.com/jenkins-x/go-scm v1.11.29
 	github.com/jenkins-x/jx-api/v4 v4.6.2
 	github.com/jenkins-x/jx-helpers/v3 v3.4.2

--- a/go.sum
+++ b/go.sum
@@ -1087,8 +1087,8 @@ github.com/jenkins-x-plugins/jx-gitops v0.10.5 h1:nK4RMFXGKCtLUvjt5fsHLKvrS4fC4R
 github.com/jenkins-x-plugins/jx-gitops v0.10.5/go.mod h1:qTu+3fSn0Li65buMLGYez4I6OOwPZkElLXF5eeXL8ts=
 github.com/jenkins-x-plugins/jx-pipeline v0.5.9 h1:H01nNliAHmo+GutJqNFdppkqfZ0UOhPTWZJ5/d4S460=
 github.com/jenkins-x-plugins/jx-pipeline v0.5.9/go.mod h1:iJwAbFdC7JJm94+daCjjmcGO50nmxtgnqdOq4SGHdFc=
-github.com/jenkins-x-plugins/jx-promote v0.4.4 h1:02olyvgiSJoU+chPgEL2w9NDuRK13OOEtCfgoPs4y9U=
-github.com/jenkins-x-plugins/jx-promote v0.4.4/go.mod h1:8EP7QkluIHhnQg35Vadm3g6NebGQjFSmcuYZYMGU+RY=
+github.com/jenkins-x-plugins/jx-promote v0.4.5 h1:47ekU3x3VHR9F+jtTFEC5L2axj/Gq/oWAEsH+p8oR+4=
+github.com/jenkins-x-plugins/jx-promote v0.4.5/go.mod h1:8EP7QkluIHhnQg35Vadm3g6NebGQjFSmcuYZYMGU+RY=
 github.com/jenkins-x/go-scm v1.11.29 h1:SXpqD+ZTs9yMH9FHfX3ysXOq6RaKO9vVdwaqDoqMJNA=
 github.com/jenkins-x/go-scm v1.11.29/go.mod h1:s5AZIMeNzvDHRnOG1nhD/OLZZ/LOwHTGLXehCsjwGuo=
 github.com/jenkins-x/jx-api/v4 v4.6.2 h1:RuS5pyPUhVe19CpUStA+1Bqmv1B3kLFyng8Wd6KYOxs=

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -95,6 +95,7 @@ func NewCmdPullRequest() (*cobra.Command, *Options) {
 	eo := &o.EnvironmentPullRequestOptions
 	cmd.Flags().StringVarP(&eo.CommitTitle, "commit-title", "", "", "the commit title")
 	cmd.Flags().StringVarP(&eo.CommitMessage, "commit-message", "", "", "the commit message")
+	cmd.Flags().StringVarP(&eo.BaseBranchName, "base-branch-name", "b", "", "the base branch name to use for new pull requests")
 
 	return cmd, o
 }


### PR DESCRIPTION
This PR adds optional parameter `--base-branch-name` to `pr` command to be able to specify remote base branch name when creating new pull requests for different release trains, i.e.

```
jx-updatebot pr --base-branch-name 1.1.x
```

It depends on the code changes in the `jx-promote` PR to be able to use it: https://github.com/jenkins-x-plugins/jx-promote/pull/409