### PR TITLE
fix(pr): reset base branch name for each rule url

### DIFF
--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -138,6 +138,8 @@ func (o *Options) Run() error {
 		}
 	}
 
+	BaseBranchName := o.BaseBranchName
+
 	for i := range o.UpdateConfig.Spec.Rules {
 		rule := &o.UpdateConfig.Spec.Rules[i]
 		err = o.FindURLs(rule)
@@ -165,6 +167,8 @@ func (o *Options) Run() error {
 
 			// lets clear the branch name so we create a new one each time in a loop
 			o.BranchName = ""
+			// lets reset the base branch name each time in a loop to avoid side effects when reusing pull requests
+			o.BaseBranchName = BaseBranchName
 
 			source := ""
 			details := &scm.PullRequest{


### PR DESCRIPTION
This PR fixes critical error caused by base branch name option value corrupted with remote pr branch name for multiple urls in updatebot.yml config