### PR TITLE
fix: change to base image that has go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ LABEL org.opencontainers.image.source https://github.com/jenkins-x-plugins/jx-up
 
 ENTRYPOINT ["jx-updatebot"]
 
+RUN apk --no-cache add git
 RUN jx upgrade plugins --boot --path /usr/bin
 
 COPY ./build/linux/jx-updatebot /usr/bin/jx-updatebot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM ghcr.io/jenkins-x/jx-boot:latest
+FROM ghcr.io/jenkins-x/jx-go:latest
 
 LABEL org.opencontainers.image.source https://github.com/jenkins-x-plugins/jx-updatebot
 
 ENTRYPOINT ["jx-updatebot"]
+
+RUN jx upgrade plugins --boot --path /usr/bin
 
 COPY ./build/linux/jx-updatebot /usr/bin/jx-updatebot


### PR DESCRIPTION
Go changes require the go command.

Should fix problems like in https://dashboard-jx.infra.jenkins-x.rocks/ns-jx/jenkins-x-plugins/jx-pipeline/main/24

Partially reverts jenkins-x-plugins/jx-updatebot#56