### PR TITLE
feat: assignable downstream commits

### DIFF
--- a/pkg/apis/updatebot/v1alpha1/types.go
+++ b/pkg/apis/updatebot/v1alpha1/types.go
@@ -48,6 +48,12 @@ type Rule struct {
 	// SparseCheckout governs if sparse checkout is made of repository. Only possible with regex and go changes.
 	// Note: Not all git servers support this.
 	SparseCheckout bool `json:"sparseCheckout,omitempty"`
+
+	// PullRequestAssignees
+	PullRequestAssignees []string `json:"pullRequestAssignees,omitempty"`
+
+	// AssignAuthorToPullRequests governs if downstream pull requests are automatically assigned to the upstream author
+	AssignAuthorToPullRequests bool `json:"assignAuthorToPullRequests,omitempty"`
 }
 
 // Change the kind of change to make on a repository

--- a/pkg/cmd/pr/test_data/assignauthor/.jx/updatebot.yaml
+++ b/pkg/cmd/pr/test_data/assignauthor/.jx/updatebot.yaml
@@ -1,0 +1,19 @@
+apiVersion: updatebot.jenkins-x.io/v1alpha1
+kind: UpdateConfig
+spec:
+  rules:
+  - urls:
+    - https://github.com/jx3-gitops-repositories/jx3-kubernetes
+    changes:
+    - command:
+        name: sh
+        args:
+        - -c
+        - "echo $CHEESE > cheese.txt"
+        env:
+        - name: CHEESE
+          value: Edam
+    pullRequestAssignees:
+      - foo
+      - bar
+    assignAuthorToPullRequests: true


### PR DESCRIPTION
Adds the ability to assign a list of users to any downstream PRs generated by updatebot. Can also assign the author of the upstream commit by setting `spec.rules.assignAuthorToPullRequests: true` within `updatebot.yaml`, see `pkg/cmd/pr/test_data/assignauthor/.jx/updatebot.yaml` as an example.

Assumes user(s) can be assigned to downstream dependent repositories. Tested and validated with GitHub.