### PR TITLE
fix: use single helper to prevent loop closure bug

### DIFF
--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -378,12 +378,11 @@ func (o *Options) ProcessRule(rule *v1alpha1.Rule, index int) error {
 
 // ProcessAndCreatePullRequests handles the URL loop, sets the closure, and creates/reuses PRs.
 func (o *Options) ProcessAndCreatePullRequests(rule *v1alpha1.Rule, baseBranch string, labels []string, automerge bool) error {
-	for _, url := range rule.URLs {
-		if url == "" {
+	for _, ruleURL := range rule.URLs {
+		if ruleURL == "" {
 			log.Logger().Warnf("skipping empty git URL")
 			continue
 		}
-		ruleURL := url
 		o.BranchName = ""
 		o.BaseBranchName = baseBranch
 

--- a/pkg/cmd/pr/pr_test.go
+++ b/pkg/cmd/pr/pr_test.go
@@ -134,6 +134,7 @@ func TestAssignAuthorToCommit(t *testing.T) {
 		o.ScmClientFactory.NoWriteGitCredentialsFile = true
 		o.Version = "1.2.3"
 		o.PipelineCommitSha = "dummy-sha"
+		o.PipelineRepoURL = "https://github.com/testorg/testing.git"
 		o.EnvironmentPullRequestOptions.ScmClientFactory.GitServerURL = "https://github.com"
 		o.EnvironmentPullRequestOptions.ScmClientFactory.GitToken = "dummytoken"
 		o.EnvironmentPullRequestOptions.ScmClientFactory.GitUsername = "dummyuser"


### PR DESCRIPTION
The recent refactor split a single processing loop into two. This caused a bug where loop variables changed between loops.

Bug emerges when pipeline base branch differs from the downstream repo (e.g.: `origin/main` versus `origin/master`).