### PR TITLE
fix: use application name when setting commit details

### DIFF
--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -331,19 +331,18 @@ func (o *Options) SetCommitDetails(dir, commitMessage, commitTitle, application 
 				} else if gitURL != "" {
 					if application == "" {
 						gitURLPart := strings.Split(gitURL, "/")
-						o.Application = gitURLPart[len(gitURLPart)-2] + "/" +
+						application = gitURLPart[len(gitURLPart)-2] + "/" +
 							strings.TrimSuffix(gitURLPart[len(gitURLPart)-1], ".git")
 					}
 					if commitMessage == "" {
 						o.CommitMessage = fmt.Sprintf("from: %s\n", gitURL)
 					}
-				}
-
-				if commitTitle == "" {
-					if application == "" {
-						o.CommitTitle = fmt.Sprintf("chore(deps): upgrade to version %s", o.Version)
-					} else {
-						o.CommitTitle = fmt.Sprintf("chore(deps): upgrade %s to version %s", o.Application, o.Version)
+					if commitTitle == "" {
+						if application == "" {
+							o.CommitTitle = fmt.Sprintf("chore(deps): upgrade to version %s", o.Version)
+						} else {
+							o.CommitTitle = fmt.Sprintf("chore(deps): upgrade %s to version %s", application, o.Version)
+						}
 					}
 				}
 				return nil

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -324,28 +324,26 @@ func (o *Options) SetChangeLog(addChangeLog string) error {
 func (o *Options) SetCommitDetails(dir string) error {
 	if o.CommitMessage == "" || o.CommitTitle == "" || o.Application == "" {
 		if o.Application == "" || o.CommitMessage == "" {
-			{
-				gitURL, err := gitdiscovery.FindGitURLFromDir(dir, true)
-				if err != nil {
-					log.Logger().Warnf("failed to find git URL %s", err.Error())
-				} else if gitURL != "" {
-					if o.Application == "" {
-						gitURLPart := strings.Split(gitURL, "/")
-						o.Application = gitURLPart[len(gitURLPart)-2] + "/" +
-							strings.TrimSuffix(gitURLPart[len(gitURLPart)-1], ".git")
-					}
-					if o.CommitMessage == "" {
-						o.CommitMessage = fmt.Sprintf("from: %s\n", gitURL)
-					}
-					if o.CommitTitle == "" {
-						if o.Application == "" {
-							o.CommitTitle = fmt.Sprintf("chore(deps): upgrade to version %s", o.Version)
-						} else {
-							o.CommitTitle = fmt.Sprintf("chore(deps): upgrade %s to version %s", o.Application, o.Version)
-						}
-					}
+			gitURL, err := gitdiscovery.FindGitURLFromDir(dir, true)
+			if err != nil {
+				log.Logger().Warnf("failed to find git URL %s", err.Error())
+			} else if gitURL != "" {
+				if o.Application == "" {
+					gitURLPart := strings.Split(gitURL, "/")
+					o.Application = gitURLPart[len(gitURLPart)-2] + "/" +
+						strings.TrimSuffix(gitURLPart[len(gitURLPart)-1], ".git")
 				}
-				return nil
+				if o.CommitMessage == "" {
+					o.CommitMessage = fmt.Sprintf("from: %s\n", gitURL)
+				}
+			}
+		}
+
+		if o.CommitTitle == "" {
+			if o.Application == "" {
+				o.CommitTitle = fmt.Sprintf("chore(deps): upgrade to version %s", o.Version)
+			} else {
+				o.CommitTitle = fmt.Sprintf("chore(deps): upgrade %s to version %s", o.Application, o.Version)
 			}
 		}
 	}

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -110,7 +110,7 @@ func (o *Options) Run() error {
 	}
 
 	// Auto-discover git URL and commit details if not provided
-	err = o.SetCommitDetails(o.Dir, o.CommitMessage, o.CommitTitle, o.Application)
+	err = o.SetCommitDetails(o.Dir)
 	if err != nil {
 		return fmt.Errorf("failed to set commit details: %w", err)
 	}
@@ -321,27 +321,27 @@ func (o *Options) SetChangeLog(addChangeLog string) error {
 }
 
 // SetCommitDetails discovers the git URL, and sets the application name, commit message and title
-func (o *Options) SetCommitDetails(dir, commitMessage, commitTitle, application string) error {
-	if commitMessage == "" || commitTitle == "" || application == "" {
-		if application == "" || commitMessage == "" {
+func (o *Options) SetCommitDetails(dir string) error {
+	if o.CommitMessage == "" || o.CommitTitle == "" || o.Application == "" {
+		if o.Application == "" || o.CommitMessage == "" {
 			{
 				gitURL, err := gitdiscovery.FindGitURLFromDir(dir, true)
 				if err != nil {
 					log.Logger().Warnf("failed to find git URL %s", err.Error())
 				} else if gitURL != "" {
-					if application == "" {
+					if o.Application == "" {
 						gitURLPart := strings.Split(gitURL, "/")
-						application = gitURLPart[len(gitURLPart)-2] + "/" +
+						o.Application = gitURLPart[len(gitURLPart)-2] + "/" +
 							strings.TrimSuffix(gitURLPart[len(gitURLPart)-1], ".git")
 					}
-					if commitMessage == "" {
+					if o.CommitMessage == "" {
 						o.CommitMessage = fmt.Sprintf("from: %s\n", gitURL)
 					}
-					if commitTitle == "" {
-						if application == "" {
+					if o.CommitTitle == "" {
+						if o.Application == "" {
 							o.CommitTitle = fmt.Sprintf("chore(deps): upgrade to version %s", o.Version)
 						} else {
-							o.CommitTitle = fmt.Sprintf("chore(deps): upgrade %s to version %s", application, o.Version)
+							o.CommitTitle = fmt.Sprintf("chore(deps): upgrade %s to version %s", o.Application, o.Version)
 						}
 					}
 				}


### PR DESCRIPTION
This fixes a bug where the commit title never adds the application name to downstream PRs